### PR TITLE
Add 5px to textarea scrollheight to remove scrollbars.

### DIFF
--- a/src/components/resizing-textarea.tsx
+++ b/src/components/resizing-textarea.tsx
@@ -18,7 +18,7 @@ export default class ResizingTextarea extends Component<ResizingTextareaProps, {
 
     __onInput(evt) {
         this.textarea.style.height = "auto";
-        this.textarea.style.height = this.textarea.scrollHeight + "px";
+        this.textarea.style.height = (this.textarea.scrollHeight + 5) + "px";
         this.props.onInput(evt);
     }
 


### PR DESCRIPTION
This might be fixed by CSS but adding 5px also seems to be an acceptable method of fixing this issue.

The issue itself looks like this (note the scrollbars):

![](https://pshuu.moe/1Bw/xDsYmY.png)