### PR TITLE
Why did we kill moment?

### DIFF
--- a/__tests__/src/lib/datelib.ts
+++ b/__tests__/src/lib/datelib.ts
@@ -1,73 +1,75 @@
 import {wasYesterday} from "lib/datelib";
 
+const newHumanDate = (year, month, day) => newHumanDate(year, month - 1, day);
+
 
 describe("wasYesterday", function() {
     it("should decide 5/21 came before 5/22", function() {
-        let today = new Date(2017, 5, 22);
-        let yesterday = new Date(2017, 5, 21);
+        let today = newHumanDate(2017, 5, 22);
+        let yesterday = newHumanDate(2017, 5, 21);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 5/22 did not come before 5/21", function() {
-        let today = new Date(2017, 5, 22);
-        let yesterday = new Date(2017, 5, 21);
+        let today = newHumanDate(2017, 5, 22);
+        let yesterday = newHumanDate(2017, 5, 21);
         
         expect(wasYesterday(today, yesterday)).toEqual(false);
     });
     
     it("should decide 4/30 came before 5/1", function() {
-        let today = new Date(2017, 5, 1);
-        let yesterday = new Date(2017, 4, 30);
+        let today = newHumanDate(2017, 5, 1);
+        let yesterday = newHumanDate(2017, 4, 30);
         
         expect(wasYesterday(yesterday, todayy)).toEqual(true);
     });
     
     it("should decide 7/31 came before 8/1", function() {
-        let today = new Date(2017, 8, 1);
-        let yesterday = new Date(2017, 7, 31);
+        let today = newHumanDate(2017, 8, 1);
+        let yesterday = newHumanDate(2017, 7, 31);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 8/31 came before 9/1", function() {
-        let today = new Date(2017, 9, 1);
-        let yesterday = new Date(2017, 8, 31);
+        let today = newHumanDate(2017, 9, 1);
+        let yesterday = newHumanDate(2017, 8, 31);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 2/28/2017 came before 3/1/2017", function() {
-        let today = new Date(2017, 3, 1);
-        let yesterday = new Date(2017, 2, 28);
+        let today = newHumanDate(2017, 3, 1);
+        let yesterday = newHumanDate(2017, 2, 28);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 2/28/2016 did not come before 3/1/2016", function() {
-        let today = new Date(2016, 3, 1);
-        let yesterday = new Date(2016, 2, 28);
+        let today = newHumanDate(2016, 3, 1);
+        let yesterday = newHumanDate(2016, 2, 28);
         
         expect(wasYesterday(yesterday, today)).toEqual(false);
     });
     
     it("should decide 2/29/2016 came before 3/1/2016", function() {
-        let today = new Date(2016, 3, 1);
-        let yesterday = new Date(2016, 2, 29);
+        let today = newHumanDate(2016, 3, 1);
+        let yesterday = newHumanDate(2016, 2, 29);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 2/29/2000 came before 3/1/2000", function() {
-        let today = new Date(2000, 3, 1);
-        let yesterday = new Date(2000, 2, 29);
+        let today = newHumanDate(2000, 3, 1);
+        let yesterday = newHumanDate(2000, 2, 29);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 12/31/2016 came before 1/1/2017", function() {
-        let today = new Date(2017, 1, 1);
-        let yesterday = new Date(2016, 12, 31);
+        let today = newHumanDate(2017, 1, 1);
+        let yesterday = newHumanDate(2016, 12, 31);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });

--- a/__tests__/src/lib/datelib.ts
+++ b/__tests__/src/lib/datelib.ts
@@ -22,7 +22,7 @@ describe("wasYesterday", function() {
         let today = newHumanDate(2017, 5, 1);
         let yesterday = newHumanDate(2017, 4, 30);
         
-        expect(wasYesterday(yesterday, todayy)).toEqual(true);
+        expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 7/31 came before 8/1", function() {

--- a/__tests__/src/lib/datelib.ts
+++ b/__tests__/src/lib/datelib.ts
@@ -73,5 +73,19 @@ describe("wasYesterday", function() {
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
+    
+    it("should decide 12/31/2016 came before 1/1/2017", function() {
+        let today = newHumanDate(2017, 1, 1);
+        let yesterday = newHumanDate(2016, 12, 31);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(true);
+    });
+    
+    it("should decide 8/21/2016 did not come before 8/22/2017", function() {
+        let today = newHumanDate(2017, 8, 22);
+        let notYesterday = newHumanDate(2016, 8, 21);
+        
+        expect(wasYesterday(notYesterday, today)).toEqual(false);
+    });
 
 });

--- a/__tests__/src/lib/datelib.ts
+++ b/__tests__/src/lib/datelib.ts
@@ -1,0 +1,75 @@
+import {wasYesterday} from "lib/datelib";
+
+
+describe("wasYesterday", function() {
+    it("should decide 5/21 came before 5/22", function() {
+        let today = new Date(2017, 05, 22);
+        let yesterday = new Date(2017, 05, 21);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(true);
+    });
+    
+    it("should decide 5/22 did not come before 5/21", function() {
+        let today = new Date(2017, 05, 22);
+        let yesterday = new Date(2017, 05, 21);
+        
+        expect(wasYesterday(today, yesterday)).toEqual(false);
+    });
+    
+    it("should decide 4/30 came before 5/1", function() {
+        let today = new Date(2017, 05, 01);
+        let yesterday = new Date(2017, 04, 30);
+        
+        expect(wasYesterday(yesterday, todayy)).toEqual(true);
+    });
+    
+    it("should decide 7/31 came before 8/1", function() {
+        let today = new Date(2017, 08, 01);
+        let yesterday = new Date(2017, 07, 31);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(true);
+    });
+    
+    it("should decide 8/31 came before 9/1", function() {
+        let today = new Date(2017, 09, 01);
+        let yesterday = new Date(2017, 08, 31);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(true);
+    });
+    
+    it("should decide 2/28/2017 came before 3/1/2017", function() {
+        let today = new Date(2017, 03, 01);
+        let yesterday = new Date(2017, 02, 28);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(true);
+    });
+    
+    it("should decide 2/28/2016 did not come before 3/1/2016", function() {
+        let today = new Date(2016, 03, 01);
+        let yesterday = new Date(2016, 02, 28);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(false);
+    });
+    
+    it("should decide 2/29/2016 came before 3/1/2016", function() {
+        let today = new Date(2016, 03, 01);
+        let yesterday = new Date(2016, 02, 29);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(true);
+    });
+    
+    it("should decide 2/29/2000 came before 3/1/2000", function() {
+        let today = new Date(2000, 03, 01);
+        let yesterday = new Date(2000, 02, 29);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(true);
+    });
+    
+    it("should decide 12/31/2016 came before 1/1/2017", function() {
+        let today = new Date(2017, 01, 01);
+        let yesterday = new Date(2016, 12, 31);
+        
+        expect(wasYesterday(yesterday, today)).toEqual(true);
+    });
+
+});

--- a/__tests__/src/lib/datelib.ts
+++ b/__tests__/src/lib/datelib.ts
@@ -3,70 +3,70 @@ import {wasYesterday} from "lib/datelib";
 
 describe("wasYesterday", function() {
     it("should decide 5/21 came before 5/22", function() {
-        let today = new Date(2017, 05, 22);
-        let yesterday = new Date(2017, 05, 21);
+        let today = new Date(2017, 5, 22);
+        let yesterday = new Date(2017, 5, 21);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 5/22 did not come before 5/21", function() {
-        let today = new Date(2017, 05, 22);
-        let yesterday = new Date(2017, 05, 21);
+        let today = new Date(2017, 5, 22);
+        let yesterday = new Date(2017, 5, 21);
         
         expect(wasYesterday(today, yesterday)).toEqual(false);
     });
     
     it("should decide 4/30 came before 5/1", function() {
-        let today = new Date(2017, 05, 01);
-        let yesterday = new Date(2017, 04, 30);
+        let today = new Date(2017, 5, 01);
+        let yesterday = new Date(2017, 4, 30);
         
         expect(wasYesterday(yesterday, todayy)).toEqual(true);
     });
     
     it("should decide 7/31 came before 8/1", function() {
-        let today = new Date(2017, 08, 01);
-        let yesterday = new Date(2017, 07, 31);
+        let today = new Date(2017, 8, 01);
+        let yesterday = new Date(2017, 7, 31);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 8/31 came before 9/1", function() {
-        let today = new Date(2017, 09, 01);
-        let yesterday = new Date(2017, 08, 31);
+        let today = new Date(2017, 9, 01);
+        let yesterday = new Date(2017, 8, 31);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 2/28/2017 came before 3/1/2017", function() {
-        let today = new Date(2017, 03, 01);
-        let yesterday = new Date(2017, 02, 28);
+        let today = new Date(2017, 3, 1);
+        let yesterday = new Date(2017, 2, 28);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 2/28/2016 did not come before 3/1/2016", function() {
-        let today = new Date(2016, 03, 01);
-        let yesterday = new Date(2016, 02, 28);
+        let today = new Date(2016, 3, 1);
+        let yesterday = new Date(2016, 2, 28);
         
         expect(wasYesterday(yesterday, today)).toEqual(false);
     });
     
     it("should decide 2/29/2016 came before 3/1/2016", function() {
-        let today = new Date(2016, 03, 01);
-        let yesterday = new Date(2016, 02, 29);
+        let today = new Date(2016, 3, 1);
+        let yesterday = new Date(2016, 2, 29);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 2/29/2000 came before 3/1/2000", function() {
-        let today = new Date(2000, 03, 01);
-        let yesterday = new Date(2000, 02, 29);
+        let today = new Date(2000, 3, 1);
+        let yesterday = new Date(2000, 2, 29);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 12/31/2016 came before 1/1/2017", function() {
-        let today = new Date(2017, 01, 01);
+        let today = new Date(2017, 1, 1);
         let yesterday = new Date(2016, 12, 31);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);

--- a/__tests__/src/lib/datelib.ts
+++ b/__tests__/src/lib/datelib.ts
@@ -17,21 +17,21 @@ describe("wasYesterday", function() {
     });
     
     it("should decide 4/30 came before 5/1", function() {
-        let today = new Date(2017, 5, 01);
+        let today = new Date(2017, 5, 1);
         let yesterday = new Date(2017, 4, 30);
         
         expect(wasYesterday(yesterday, todayy)).toEqual(true);
     });
     
     it("should decide 7/31 came before 8/1", function() {
-        let today = new Date(2017, 8, 01);
+        let today = new Date(2017, 8, 1);
         let yesterday = new Date(2017, 7, 31);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);
     });
     
     it("should decide 8/31 came before 9/1", function() {
-        let today = new Date(2017, 9, 01);
+        let today = new Date(2017, 9, 1);
         let yesterday = new Date(2017, 8, 31);
         
         expect(wasYesterday(yesterday, today)).toEqual(true);

--- a/__tests__/src/lib/datelib.ts
+++ b/__tests__/src/lib/datelib.ts
@@ -1,6 +1,6 @@
 import {wasYesterday} from "lib/datelib";
 
-const newHumanDate = (year, month, day) => newHumanDate(year, month - 1, day);
+const newHumanDate = (year, month, day) => new Date(year, month - 1, day);
 
 
 describe("wasYesterday", function() {

--- a/src/components/quote.tsx
+++ b/src/components/quote.tsx
@@ -3,6 +3,7 @@ import {Link} from "inferno-router";
 import fecha from "fecha";
 
 import classifyQuote from "../lib/classifyquote";
+import {wasYesterday} from "../lib/datelib";
 
 require("../../style/quote.scss");
 
@@ -83,9 +84,9 @@ const Quote = ({id, author, body, addedAt}) => {
     let addedAtDate = new Date(addedAt);
     let now = new Date();
     let addedAtRelative =
-        (addedAtDate.getDay() === now.getDay()) ?
+        (addedAtDate.getDate() === now.getDate()) ?
         fecha.format(addedAtDate, "[Today at] h:mma") :
-        (addedAtDate.getDay() === now.getDay() - 1) ?
+        wasYesterday(addedAtDate, now) ?
         fecha.format(addedAtDate, "[Yesterday at] h:mma") :
         (addedAtDate.getFullYear() === now.getFullYear()) ?
         fecha.format(addedAtDate, "MMMM D [at] h:mma") :

--- a/src/lib/datelib.ts
+++ b/src/lib/datelib.ts
@@ -5,7 +5,7 @@ export function wasYesterday(date : Date, now : Date) : boolean {
     if (isLeapYear) {
         daysInMonth[1] = 29;
     }
-    
+
     if (now.getDate() === 1) {
         if (now.getMonth() === 0) {
             return (date.getMonth() === 11) && (date.getDate() === 31);

--- a/src/lib/datelib.ts
+++ b/src/lib/datelib.ts
@@ -1,0 +1,19 @@
+// This is my "oh boy I really wish we used a real date library" cosplay.
+export function wasYesterday(date : Date, now : Date) : boolean {
+    let daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let isLeapYear = (now.getFullYear() % 4 == 0) && ((now.getFullYear() % 100 != 0) || (now.getFullYear() % 400 == 0));
+    if (isLeapYear) {
+        daysInMonth[1] = 29;
+    }
+    
+    if (now.getDate() == 1) {
+        if (now.getMonth() == 0) {
+            return (date.getMonth() == 11) && (date.getDate() == 31);
+        } else {
+            let lastMonth = now.getMonth() - 1;
+            return (date.getMonth() == lastMonth) && (date.getDate() == daysInMonth[lastMonth]);
+        }
+    } else {
+        return (date.getMonth() == now.getMonth()) && (date.getDate() == now.getDate() - 1);
+    }
+}

--- a/src/lib/datelib.ts
+++ b/src/lib/datelib.ts
@@ -1,19 +1,19 @@
 // This is my "oh boy I really wish we used a real date library" cosplay.
 export function wasYesterday(date : Date, now : Date) : boolean {
     let daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-    let isLeapYear = (now.getFullYear() % 4 == 0) && ((now.getFullYear() % 100 != 0) || (now.getFullYear() % 400 == 0));
+    let isLeapYear = (now.getFullYear() % 4 === 0) && ((now.getFullYear() % 100 !== 0) || (now.getFullYear() % 400 === 0));
     if (isLeapYear) {
         daysInMonth[1] = 29;
     }
     
-    if (now.getDate() == 1) {
-        if (now.getMonth() == 0) {
-            return (date.getMonth() == 11) && (date.getDate() == 31);
+    if (now.getDate() === 1) {
+        if (now.getMonth() === 0) {
+            return (date.getMonth() === 11) && (date.getDate() === 31);
         } else {
             let lastMonth = now.getMonth() - 1;
-            return (date.getMonth() == lastMonth) && (date.getDate() == daysInMonth[lastMonth]);
+            return (date.getMonth() === lastMonth) && (date.getDate() === daysInMonth[lastMonth]);
         }
     } else {
-        return (date.getMonth() == now.getMonth()) && (date.getDate() == now.getDate() - 1);
+        return (date.getMonth() === now.getMonth()) && (date.getDate() === now.getDate() - 1);
     }
 }

--- a/src/lib/datelib.ts
+++ b/src/lib/datelib.ts
@@ -8,12 +8,12 @@ export function wasYesterday(date : Date, now : Date) : boolean {
 
     if (now.getDate() === 1) {
         if (now.getMonth() === 0) {
-            return (date.getMonth() === 11) && (date.getDate() === 31);
+            return (date.getYear() === now.getYear() - 1) && (date.getMonth() === 11) && (date.getDate() === 31);
         } else {
             let lastMonth = now.getMonth() - 1;
-            return (date.getMonth() === lastMonth) && (date.getDate() === daysInMonth[lastMonth]);
+            return (date.getYear() === now.getYear()) && (date.getMonth() === lastMonth) && (date.getDate() === daysInMonth[lastMonth]);
         }
     } else {
-        return (date.getMonth() === now.getMonth()) && (date.getDate() === now.getDate() - 1);
+        return (date.getYear() === now.getYear()) && (date.getMonth() === now.getMonth()) && (date.getDate() === now.getDate() - 1);
     }
 }

--- a/src/lib/datelib.ts
+++ b/src/lib/datelib.ts
@@ -8,12 +8,12 @@ export function wasYesterday(date : Date, now : Date) : boolean {
 
     if (now.getDate() === 1) {
         if (now.getMonth() === 0) {
-            return (date.getYear() === now.getYear() - 1) && (date.getMonth() === 11) && (date.getDate() === 31);
+            return (date.getFullYear() === now.getFullYear() - 1) && (date.getMonth() === 11) && (date.getDate() === 31);
         } else {
             let lastMonth = now.getMonth() - 1;
-            return (date.getYear() === now.getYear()) && (date.getMonth() === lastMonth) && (date.getDate() === daysInMonth[lastMonth]);
+            return (date.getFullYear() === now.getFullYear()) && (date.getMonth() === lastMonth) && (date.getDate() === daysInMonth[lastMonth]);
         }
     } else {
-        return (date.getYear() === now.getYear()) && (date.getMonth() === now.getMonth()) && (date.getDate() === now.getDate() - 1);
+        return (date.getFullYear() === now.getFullYear()) && (date.getMonth() === now.getMonth()) && (date.getDate() === now.getDate() - 1);
     }
 }


### PR DESCRIPTION
This is surely very far away for yesterday:

![](https://pshuu.moe/1Bx/At1CFy.png)

`.getDay()` returns a day of the week. Rather than kill relative time I thought it would be a better idea to reinvent the wheel, and here we are.