### PR TITLE
fecha exports changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/express": "^4.0.35",
     "core-js": "^2.4.1",
     "express": "^4.15.2",
-    "fecha": "^2.3.1",
+    "fecha": "^2.3.2",
     "history": "^4.6.1",
     "http-proxy-middleware": "^0.17.4",
     "inferno": "^3.1.0",

--- a/src/components/quote.tsx
+++ b/src/components/quote.tsx
@@ -1,6 +1,6 @@
 import Component from "inferno-component";
 import {Link} from "inferno-router";
-import fecha from "fecha";
+import {format} from "fecha";
 
 import classifyQuote from "../lib/classifyquote";
 import {wasYesterday} from "../lib/datelib";
@@ -85,15 +85,15 @@ const Quote = ({id, author, body, addedAt}) => {
     let now = new Date();
     let addedAtRelative =
         (addedAtDate.getDate() === now.getDate()) ?
-        fecha.format(addedAtDate, "[Today at] h:mma") :
+        format(addedAtDate, "[Today at] h:mma") :
         wasYesterday(addedAtDate, now) ?
-        fecha.format(addedAtDate, "[Yesterday at] h:mma") :
+        format(addedAtDate, "[Yesterday at] h:mma") :
         (addedAtDate.getFullYear() === now.getFullYear()) ?
-        fecha.format(addedAtDate, "MMMM D [at] h:mma") :
-        fecha.format(addedAtDate, "MMMM D, YYYY [at] h:mma");
+        format(addedAtDate, "MMMM D [at] h:mma") :
+        format(addedAtDate, "MMMM D, YYYY [at] h:mma");
 
     let addedAtReal =
-        fecha.format(addedAtDate, "dddd, MMMM D, YYYY [at] h:mma");
+        format(addedAtDate, "dddd, MMMM D, YYYY [at] h:mma");
 
     return (
         <article class="quote">


### PR DESCRIPTION
At some point fecha changed its type definitions to `export as namespace Fecha` instead of `export = Fecha` so we started getting build errors despite not changing our dependencies ¯\\\_(ツ)_/¯